### PR TITLE
BUG: Change revision of SlicerExecutionModel

### DIFF
--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -82,7 +82,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
   ### --- End Project specific additions
   set(${proj}_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git")
-  set(${proj}_GIT_TAG 18cdc5a9d489f381acd7666668efa8d57ef08e47)
+  set(${proj}_GIT_TAG 608c7b06f9402b35f0ec01550a3b9e313582f683)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
Change the revision of SlicerExecutionModel.
The SEMMacro changed and it adds some variables used by CMake
